### PR TITLE
v.2.7.1 - Detailverbesserungen: Updatesuche/Filmsuche/Log

### DIFF
--- a/RSScrawler.py
+++ b/RSScrawler.py
@@ -134,7 +134,7 @@ class MB():
         ignore = "|".join(["\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if not self.config.get("ignore") == "" else "^unmatchable$"
         
         for key in self.allInfos:
-            s = re.sub(self.SUBSTITUTE,".",key).lower()
+            s = re.sub(self.SUBSTITUTE,".","^" + key).lower()
             for post in feed.entries:
                 found = re.search(s,post.title.lower())
                 if found:
@@ -325,7 +325,7 @@ class MB():
                                         retail = True
 
                         # Logge gefundenes Release auch im RSScrawler (Konsole/Logdatei)
-                        self.log_info('[Film] - ' + (' - <b>Retail</b> - ' if retail else "") + key.replace('*ENGLISCH*', '') + ' - [<a href="' + download_link + '" target="_blank">Link</a>]')
+                        self.log_info('[Film] - ' + ('<b>Retail</b> - ' if retail else "") + key.replace('*ENGLISCH*', '') + ' - [<a href="' + download_link + '" target="_blank">Link</a>]')
 
                         # Schreibe Crawljob  
                         common.write_crawljob_file(
@@ -400,7 +400,7 @@ class MB3d():
         ignore = "|".join(["\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if not self.config.get("ignore") == "" else "^unmatchable$"
         
         for key in self.allInfos:
-            s = re.sub(self.SUBSTITUTE,".",key).lower()
+            s = re.sub(self.SUBSTITUTE,".","^" + key).lower()
             for post in feed.entries:
                 found = re.search(s,post.title.lower())
                 if found:
@@ -661,7 +661,7 @@ class MBstaffeln():
         ignore = "|".join(["\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if not self.config.get("ignore") == "" else "^unmatchable$"
         
         for key in self.allInfos:
-            s = re.sub(self.SUBSTITUTE,".",key).lower()
+            s = re.sub(self.SUBSTITUTE,".","^" + key).lower()
             for post in feed.entries:
                 found = re.search(s,post.title.lower())
                 if found:
@@ -919,7 +919,7 @@ class MBregex():
 
     def searchLinks(self, feed):
         for key in self.allInfos:
-            s = re.sub(self.SUBSTITUTE,".",key).lower()
+            s = re.sub(self.SUBSTITUTE,".","^" + key).lower()
             for post in feed.entries:
                 found = re.search(s,post.title.lower())
                 if found:
@@ -1808,7 +1808,6 @@ if __name__ == "__main__":
 
     # Starte Webanwendung
     p = Process(target=cherry_server, args=(port, prefix, docker))
-    p.daemon = True
     p.start()
     files.check()
 

--- a/cherry.py
+++ b/cherry.py
@@ -24,7 +24,6 @@ class Server:
   @cherrypy.expose
   def index(self):
     jdownloader, port, prefix, interval, hoster, pushbulletapi, mbquality, ignore, historical, mbregex, cutoff, crawl3d, enforcedl, crawlseasons, seasonsquality, seasonssource, sjquality, rejectlist, sjregex, hosterso, hosterul, mbq1080, mbq720, mbq480, msq1080, msq720, msq480, sjq1080, sjq720, sjq480, historicaltrue, historicalfalse, mbregextrue, mbregexfalse, mrdiv, cutofftrue, cutofffalse, crawl3dtrue, crawl3dfalse, tddiv, enforcedltrue, enforcedlfalse, crawlseasonstrue, crawlseasonsfalse, ssdiv, sjregextrue, sjregexfalse, srdiv, dockerblocker, ytdiv, youtubetrue, youtubefalse, spacktrue, spackfalse, shdtv, shdtvweb, sweb, sbluray, swebbluray, shdtvwebbluray, maxvideos, ytignore, dockerhint = common.load(dockerglobal)
-    global updateversion
     return '''<!DOCTYPE html>
 <html lang="de">
   <head>

--- a/version.py
+++ b/version.py
@@ -3,17 +3,16 @@
 # Projekt von https://github.com/rix1337
 import re
 import urllib2
-from BeautifulSoup import BeautifulSoup
 
 def getVersion():
-    return "v.2.7.0"
+    return "v.2.7.1"
 
 def updateCheck():
     # Prüfe, ob lokale Version der aktuellen Entspricht
     localversion = getVersion()
     try:
         # Einzeiler, der die aktuelle Version von GitHub ausliest:
-        onlineversion = str(re.search('return "(.+?)"', BeautifulSoup(urllib2.urlopen('https://raw.githubusercontent.com/rix1337/RSScrawler/master/version.py').read()).findAll(text=re.compile('return "(v\.\d\.\d\.\d)"'))[0]).group(1))
+        onlineversion = re.search('return "(v\.\d{1,2}\.\d{1,2}\.\d{1,2})"', urllib2.urlopen('https://raw.githubusercontent.com/rix1337/RSScrawler/master/version.py').read()).group(1)
         if localversion == onlineversion:
             return (False, localversion)
         else:


### PR DESCRIPTION
-Suche nur noch `Filmtitel`, nicht mehr `Irgendetwas vor Filmtitel`
-Redundanter Strich in Retail-Logeintrag entfernt
-Updatesuche entschlackt
-Erlaube zweistellige Versionsnummern in Updatesuche