### PR TITLE
v.2.9.3 - Kritischer Fix für periodische Ausführung

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 # https://github.com/rix1337/RSScrawler/issues/88#issuecomment-251078409
 # https://github.com/rix1337/RSScrawler/issues/7#issuecomment-271187968
 
-VERSION="v.2.9.2"
+VERSION="v.2.9.3"
 echo "┌────────────────────────────────────────────────────────┐"
 echo "  Programminfo:    RSScrawler $VERSION von RiX"
 echo "  Projektseite:    https://github.com/rix1337/RSScrawler"

--- a/version.py
+++ b/version.py
@@ -6,7 +6,7 @@ import re
 import urllib2
 
 def getVersion():
-    return "v.2.9.2"
+    return "v.2.9.3"
 
 def updateCheck():
     # Prüfe, ob lokale Version der aktuellen Entspricht


### PR DESCRIPTION
Dieser Fix behebt ein kritisches Problem, bei dem zu lange Suchlisten zum vorzeitigen Abbruch aller Suchen führen.

**Vorher:**
Aktivierung aller Suchfunktionen -> Intervallänge wird abgewartet -> bei derem Ende wird alles beendet -> Neustart

**Jetzt:**
Aktivierung aller Suchfunktionen nacheinander -> Nach deren vollständiger Ausführung -> Wartedauer des Intervalls -> Neustart