### PR TITLE
Smarte Suchfunktion für MB/SJ

### DIFF
--- a/RSScrawler.py
+++ b/RSScrawler.py
@@ -47,13 +47,14 @@ from multiprocessing import Process
 from rssconfig import RssConfig
 from rssdb import RssDb
 from notifiers import notify
+from url import getURL
 import common
 import files
 from web import start
 
 
-def web_server(port, docker):
-    start(port, docker)
+def web_server(port, docker, jd):
+    start(port, docker, jd)
 
 def crawler(jdpath, rssc):
     global added_items
@@ -137,10 +138,6 @@ def crawler(jdpath, rssc):
             print(time.strftime("%Y-%m-%d %H:%M:%S") + " - Testlauf ausgeführt (Dauer: " + total_time + ")!")
         except Exception as e:
             print(time.strftime("%Y-%m-%d %H:%M:%S") + " - Fehler im Suchlauf: " + str(e))
-
-def getURL(url):
-    scraper = cfscrape.create_scraper(delay=10)
-    return scraper.get(url).content
 
 class YT():
     _INTERNAL_NAME='YT'
@@ -243,7 +240,7 @@ class YT():
                          video,		
                          'added'
                     )
-                    log_entry = '[YouTube] - ' + video_title + ' (' + channel + ') - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + video + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[YouTube] - ' + video_title + ' (' + channel + ') - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + video + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
 
@@ -490,7 +487,7 @@ class SJ():
         else:
             common.write_crawljob_file(title, title, link, jdownloaderpath + "/folderwatch", "RSScrawler")
             self.db.store(title, 'added')
-            log_entry = link_placeholder + title + ' - <a href="' + link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + title + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+            log_entry = link_placeholder + title + ' - <a href="' + link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + title + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
             self.log_info(log_entry)
             added_items.append(log_entry)
 
@@ -700,7 +697,7 @@ class MB():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -720,7 +717,7 @@ class MB():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -736,7 +733,7 @@ class MB():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                         )
-                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -752,7 +749,7 @@ class MB():
                         key,		
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -799,7 +796,10 @@ class MB():
             if len(item[2]) > 0:
                 download_imdb = "http://www.imdb.com/title/" + item[2]
             else:
-                search_title = re.findall(r"(.*?)(?:\.(?:(?:19|20)\d{2})|\.German|\.\d{3,4}p|\.S(?:\d{1,3})\.)", download_title)[0].replace(".", "+").replace("ae", "ä")
+                try:
+                    search_title = re.findall(r"(.*?)(?:\.(?:(?:19|20)\d{2})|\.German|\.\d{3,4}p|\.S(?:\d{1,3})\.)", download_title)[0].replace(".", "+").replace("ae", "ä").replace("oe", "ö").replace("ue", "ü").replace("Ae", "Ä").replace("Oe", "Ö").replace("Ue", "Ü")
+                except:
+                    break
                 search_url = "http://www.imdb.com/find?q=" + search_title
                 search_page = getURL(search_url)
                 search_results = re.findall(r'<td class="result_text"> <a href="\/title\/(tt[0-9]{7,9})\/\?ref_=fn_al_tt_\d" >(.*?)<\/a>.*? \((\d{4})\)..(.{9})', search_page)
@@ -959,7 +959,7 @@ class MB():
                         key,
                         'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                     )
-                    log_entry = '[IMDB ' + score + '/Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[IMDB ' + score + '/Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                 else:
@@ -981,7 +981,7 @@ class MB():
                         key,
                         'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                     )
-                    log_entry = '[IMDB ' + score + '/Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[IMDB ' + score + '/Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
 
@@ -991,8 +991,9 @@ class MB():
         download = soup.find("div", {"id": "content"})
         url_hosters = re.findall(r'href="([^"\'>]*)".+?(.+?)<', str(download))
         for url_hoster in url_hosters:
-            if self.hoster.lower() in url_hoster[1].lower():
-                return url_hoster[0]
+            if not "bW92aWUtYmxvZy5vcmcv".decode("base64") in url_hoster[0]:
+                if self.hoster.lower() in url_hoster[1].lower():
+                    return url_hoster[0]
 
     def periodical_task(self):
         if self.filename == 'MB_Filme':
@@ -1141,7 +1142,7 @@ class MB():
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_3D':
@@ -1157,13 +1158,13 @@ class MB():
                             key,
                             download_link,
                             jdownloaderpath + "/folderwatch",
-                            "RSScrawler"
+                            "RSScrawler/3Dcrawler"
                         )
                         self.db.store(
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_Staffeln':
@@ -1193,7 +1194,7 @@ class MB():
                             key,		
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
 
@@ -1361,7 +1362,7 @@ class HW():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -1381,7 +1382,7 @@ class HW():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -1397,7 +1398,7 @@ class HW():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                         )
-                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -1413,7 +1414,7 @@ class HW():
                         key,		
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -1460,7 +1461,10 @@ class HW():
             if len(item[2]) > 0:
                 download_imdb = "http://www.imdb.com/title/" + item[2]
             else:
-                search_title = re.findall(r"(.*?)(?:\.(?:(?:19|20)\d{2})|\.German|\.\d{3,4}p|\.S(?:\d{1,3})\.)", download_title)[0].replace(".", "+").replace("ae", "ä")
+                try:
+                    search_title = re.findall(r"(.*?)(?:\.(?:(?:19|20)\d{2})|\.German|\.\d{3,4}p|\.S(?:\d{1,3})\.)", download_title)[0].replace(".", "+").replace("ae", "ä").replace("oe", "ö").replace("ue", "ü").replace("Ae", "Ä").replace("Oe", "Ö").replace("Ue", "Ü")
+                except:
+                    break
                 search_url = "http://www.imdb.com/find?q=" + search_title
                 search_page = getURL(search_url)
                 search_results = re.findall(r'<td class="result_text"> <a href="\/title\/(tt[0-9]{7,9})\/\?ref_=fn_al_tt_\d" >(.*?)<\/a>.*? \((\d{4})\)..(.{9})', search_page)
@@ -1620,7 +1624,7 @@ class HW():
                         key,
                         'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                     )
-                    log_entry = '[IMDB ' + score + '/Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[IMDB ' + score + '/Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                 else:
@@ -1642,7 +1646,7 @@ class HW():
                         key,
                         'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                     )
-                    log_entry = '[IMDB ' + score + '/Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[IMDB ' + score + '/Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
 
@@ -1799,7 +1803,7 @@ class HW():
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_3D':
@@ -1815,13 +1819,13 @@ class HW():
                             key,
                             download_link,
                             jdownloaderpath + "/folderwatch",
-                            "RSScrawler"
+                            "RSScrawler/3Dcrawler"
                         )
                         self.db.store(
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_Staffeln':
@@ -1851,7 +1855,7 @@ class HW():
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
  
@@ -2040,7 +2044,7 @@ class HA():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -2060,7 +2064,7 @@ class HA():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -2076,7 +2080,7 @@ class HA():
                         key,
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                         )
-                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Film/Serie/RegEx] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -2092,7 +2096,7 @@ class HA():
                         key,		
                         'dl' if self.config.get('enforcedl') and '.dl.' in key.lower() else 'added'
                     )
-                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                    log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                     self.log_info(log_entry)
                     added_items.append(log_entry)
                     return True
@@ -2215,7 +2219,7 @@ class HA():
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_3D':
@@ -2237,7 +2241,7 @@ class HA():
                             key,
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
                     elif self.filename == 'MB_Staffeln':
@@ -2267,7 +2271,7 @@ class HA():
                             key,		
                             'notdl' if self.config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
                         )
-                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link öffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download für nächsten Suchlauf zurücksetzen"><i class="fas fa-undo"></i></a>'
+                        log_entry = '[Film/Serie/RegEx] - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                         self.log_info(log_entry)
                         added_items.append(log_entry)
 
@@ -2369,7 +2373,7 @@ if __name__ == "__main__":
         prefix = ''
     print('Der Webserver ist erreichbar unter http://' + common.checkIp() +':' + str(port) + prefix)
 
-    p = Process(target=web_server, args=(port, docker))
+    p = Process(target=web_server, args=(port, docker, jdownloaderpath))
     p.start()
     
     files.check()

--- a/RSScrawler.py
+++ b/RSScrawler.py
@@ -224,7 +224,7 @@ class YT():
                 if self.db.retrieve(video) == 'added':
                     self.log_debug("[%s] - YouTube-Video ignoriert (bereits gefunden)" % video)
                 else:
-                    ignore = "|".join(["%s" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+                    ignore = "|".join(["%s" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
                     ignorevideo = re.search(ignore,video_title.lower())
                     if ignorevideo:
                         self.log_debug(video_title + " (" + channel + ") " + "[" + video + "] - YouTube-Video ignoriert (basierend auf ignore-Einstellung)")
@@ -289,9 +289,9 @@ class SJ():
             return
         try:
             reject = self.config.get("rejectlist").replace(",", "|").lower() if len(
-                self.config.get("rejectlist")) > 0 else "^unmatchable$"
+                self.config.get("rejectlist")) > 0 else r"^unmatchable$"
         except TypeError:
-            reject = "^unmatchable$"
+            reject = r"^unmatchable$"
         self.quality = self.config.get("quality")
         self.hoster = rsscrawler.get("hoster")
 
@@ -572,7 +572,7 @@ class MB():
         if self.empty_list:
             return
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
 
         for key in self.allInfos:
             s = re.sub(self.SUBSTITUTE, ".", "^" + key).lower()
@@ -756,7 +756,7 @@ class MB():
 
     def dl_search(self, feed, title):
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
 
         s = re.sub(self.SUBSTITUTE, ".", title).lower()
         for post in feed.entries:
@@ -774,7 +774,7 @@ class MB():
         for item in imdbchecked:
             download_title = item[0]
             ignore = "|".join(
-                [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+                [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
             found = re.search(ignore, download_title.lower())
             if found:
                 self.log_debug("%s - Release ignoriert (basierend auf ignore-Einstellung)" % download_title)
@@ -1240,7 +1240,7 @@ class HW():
         if self.empty_list:
             return
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
 
         for key in self.allInfos:
             s = re.sub(self.SUBSTITUTE, ".", "^" + key).lower()
@@ -1421,7 +1421,7 @@ class HW():
 
     def dl_search(self, feed, title):
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
 
         s = re.sub(self.SUBSTITUTE, ".", title).lower()
         for post in feed.entries:
@@ -1439,7 +1439,7 @@ class HW():
         for item in imdbchecked:
             download_title = item[0]
             ignore = "|".join(
-                [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+                [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
             found = re.search(ignore, download_title.lower())
             if found:
                 self.log_debug("%s - Release ignoriert (basierend auf ignore-Einstellung)" % download_title)
@@ -1901,7 +1901,7 @@ class HA():
         if self.empty_list:
             return
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
 
         for key in self.allInfos:
             if not key.replace(" ", "+") in feed and not self.filename == 'MB_Regex':
@@ -2103,7 +2103,7 @@ class HA():
 
     def dl_search(self, feed, title):
         ignore = "|".join(
-            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else "^unmatchable$"
+            [r"\.%s(\.|-)" % p for p in self.config.get("ignore").lower().split(',')]) if self.config.get("ignore") else r"^unmatchable$"
         req_page = getURL(feed)
         soup = bs(req_page, 'lxml')
         content = soup.find("div", {"id" : "content"})

--- a/notifiers.py
+++ b/notifiers.py
@@ -29,7 +29,7 @@ def notify(added_items):
     pushover_settings = notifications.get("pushover").split(',')
     items = []
     for item in added_items:
-        item = item.replace('[<a href="', '').replace('" target="_blank">Link</a>]', '')
+        item = item.split("-")[-1]
         items.append(item)
     if len(items) > 0:
         cut_items = list(api_request_cutter(items, 5))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ docopt
 feedparser
 flask
 lxml
-requests
+requests[socks]

--- a/search.py
+++ b/search.py
@@ -20,13 +20,20 @@ def get(title):
     query = title.replace(".", " ").replace(" ", "+")
     mb = getURL("http://www.movie-blog.org/index.php?s=" + query + "+" + quality)
     mb = re.findall(r'post-.*?<a href="http:\/{2}.*?\/(.*?)" rel.*?>(.*?)<', mb)
-    results = {}
-    i = 0
+
+    unrated = []
     for result in mb:
         if not result[1].endswith("-MB") and not result[1].endswith(".MB"):
-            res = {"link": result[0].replace("/", "+"), "title": result[1]}
-            results["result" + str(i)] = res
-            i += 1
+            unrated.append([rate(result[1]), result[0].replace("/", "+"), result[1]])
+
+    rated = sorted(unrated, reverse=True)
+
+    results = {}
+    i = 0
+    for result in rated:
+        res = {"link": result[1], "title": result[2]}
+        results["result" + str(i)] = res
+        i += 1
     mb = results
 
     results = {}
@@ -42,6 +49,63 @@ def get(title):
         i += 1
     sj = results
     return mb, sj
+
+def rate(title):
+    score = 0
+    if ".bluray." in title.lower():
+        score += 7
+    if ".bd." in title.lower():
+        score += 7
+    if ".bdrip." in title.lower():
+        score += 7
+    if re.match(r'.*\-(4SJ|TVS)', title):
+        score += 4
+    if ".dl." in title.lower():
+        score += 2
+    if re.match(r'.*\.(DTS|DD\+*51|DD\+*71|AC3\.5\.*1)\..*', title):
+        score += 2
+    if re.match(r'.*\.(720|1080|2160)p\..*', title):
+        score += 2
+    if ".ml." in title.lower():
+        score += 1
+    if ".dd20." in title.lower():
+        score += 1
+    if "dubbed." in title.lower():
+        score -= 1
+    if ".synced." in title.lower():
+        score -= 1
+    if ".ac3d." in title.lower():
+        score -= 1
+    if ".dtsd." in title.lower():
+        score -= 1
+    if ".hdtv." in title.lower():
+        score -= 1
+    if ".dtv" in title.lower():
+        score -= 1
+    if ".pdtv" in title.lower():
+        score -= 1
+    if "tvrip." in title.lower():
+        score -= 1
+    if ".subbed." in title.lower():
+        score -= 2
+    if ".xvid." in title.lower():
+        score -= 2
+    if ".pal." in title.lower():
+        score -= 5
+    if "dvd9" in title.lower():
+        score -= 5
+    try:
+        config = RssConfig('SJ')
+        reject = config.get("rejectlist").replace(",", "|").lower() if len(
+            config.get("rejectlist")) > 0 else r"^unmatchable$"
+    except TypeError:
+        reject = r"^unmatchable$"
+    r = re.search(reject, title.lower())
+    if r:
+        score -= 5
+    if ".subpack." in title.lower():
+        score -= 10
+    return score
 
 def download_dl(title, jdownloaderpath, hoster, staffel, db, config):
     search_title = title.replace(".German.720p.", ".German.DL.1080p.").replace(".German.DTS.720p.", ".German.DTS.DL.1080p.").replace(".German.AC3.720p.", ".German.AC3.DL.1080p.").replace(".German.AC3LD.720p.", ".German.AC3LD.DL.1080p.").replace(".German.AC3.Dubbed.720p.", ".German.AC3.Dubbed.DL.1080p.").split('.x264-', 1)[0].split('.h264-', 1)[0].replace(".", " ").replace(" ", "+")
@@ -280,63 +344,6 @@ def mb(link, jdownloaderpath):
             return True
     else:
         return False
-
-def rate(title):
-    score = 0
-    if ".bluray." in title.lower():
-        score += 7
-    if ".bd." in title.lower():
-        score += 7
-    if ".bdrip." in title.lower():
-        score += 7
-    if re.match(r'.*\-(4SJ|TVS)', title):
-        score += 4
-    if ".dl." in title.lower():
-        score += 2
-    if re.match(r'.*\.(DTS|DD\+*51|DD\+*71|AC3\.5\.*1)\..*', title):
-        score += 2
-    if re.match(r'.*\.(720|1080|2160)p\..*', title):
-        score += 2
-    if ".ml." in title.lower():
-        score += 1
-    if ".dd20." in title.lower():
-        score += 1
-    if "dubbed." in title.lower():
-        score -= 1
-    if ".synced." in title.lower():
-        score -= 1
-    if ".ac3d." in title.lower():
-        score -= 1
-    if ".dtsd." in title.lower():
-        score -= 1
-    if ".hdtv." in title.lower():
-        score -= 1
-    if ".dtv" in title.lower():
-        score -= 1
-    if ".pdtv" in title.lower():
-        score -= 1
-    if "tvrip." in title.lower():
-        score -= 1
-    if ".subbed." in title.lower():
-        score -= 2
-    if ".xvid." in title.lower():
-        score -= 2
-    if ".pal." in title.lower():
-        score -= 5
-    if "dvd9" in title.lower():
-        score -= 5
-    try:
-        config = RssConfig('SJ')
-        reject = config.get("rejectlist").replace(",", "|").lower() if len(
-            config.get("rejectlist")) > 0 else r"^unmatchable$"
-    except TypeError:
-        reject = r"^unmatchable$"
-    r = re.search(reject, title.lower())
-    if r:
-        score -= 5
-    if ".subpack." in title.lower():
-        score -= 10
-    return score
 
 # TODO: Add title to SJ_Serien
 def sj(id, jdownloaderpath):

--- a/search.py
+++ b/search.py
@@ -15,15 +15,21 @@ import sys
 import time
 
 def get(title):
+    config = RssConfig('MB')
+    quality = config.get('quality')
     query = title.replace(".", " ").replace(" ", "+")
-    mb = getURL("http://www.movie-blog.org/index.php?s=" + query)
+    mb = getURL("http://www.movie-blog.org/index.php?s=" + query + "+" + quality)
     mb = re.findall(r'post-.*?<a href="http:\/{2}.*?\/(.*?)" rel.*?>(.*?)<', mb)
     results = []
     for result in mb:
-        results.append([result[0].replace("/", "+"), result[1]])
+        if not result[1].endswith("-MB") and not result[1].endswith(".MB"):
+            results.append([result[0].replace("/", "+"), result[1]])
     mb = results
     sj = postURL("http://serienjunkies.org/media/ajax/search/search.php", data={'string': "'" + query + "'"})
-    sj = json.loads(sj)
+    try:
+        sj = json.loads(sj)
+    except:
+        sj = []
     return mb, sj
 
 def download_dl(title, jdownloaderpath, hoster, staffel, db, config):
@@ -116,7 +122,6 @@ def dl_search(feed, title):
         if found:
             yield (post.title, [post.link], title)
 
-# TODO Resolution
 def mb(link, jdownloaderpath):
     link = link.replace("+", "/")
     url = getURL("http://movie-blog.org/" + link)
@@ -304,7 +309,7 @@ def rate(title):
 def sj(id, jdownloaderpath):
     url = getURL("http://serienjunkies.org/?cat=" + str(id))
     season_pool = re.findall(r'<h2>Staffeln:(.*?)<h2>Feeds', url).pop()
-    season_links = re.findall(r'href="(.*?)">.*?(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
+    season_links = re.findall(r'href="(.{1,90})">.{1,90}(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
     rsscrawler = RssConfig('RSScrawler')
 
     staffeln = []

--- a/search.py
+++ b/search.py
@@ -18,13 +18,13 @@ def get(title):
     config = RssConfig('MB')
     quality = config.get('quality')
     query = title.replace(".", " ").replace(" ", "+")
-    mb = getURL("http://www.movie-blog.org/index.php?s=" + query + "+" + quality)
-    mb = re.findall(r'post-.*?<a href="http:\/{2}.*?\/(.*?)" rel.*?>(.*?)<', mb)
+    mb = getURL('aHR0cDovL3d3dy5tb3ZpZS1ibG9nLm9yZw=='.decode('base64') + '/search/' + query + "+" + quality + '/feed/rss2/')
+    mb = re.findall(r'<title>(.*?)<\/title>\n.*?<link>(.*?)<\/link>', mb)
 
     unrated = []
     for result in mb:
         if not result[1].endswith("-MB") and not result[1].endswith(".MB"):
-            unrated.append([rate(result[1]), result[0].replace("/", "+"), result[1]])
+            unrated.append([rate(result[0]), result[1].replace("/", "+"), result[0]])
 
     rated = sorted(unrated, reverse=True)
 
@@ -38,7 +38,7 @@ def get(title):
 
     results = {}
     i = 0
-    sj = postURL("http://serienjunkies.org/media/ajax/search/search.php", data={'string': "'" + query + "'"})
+    sj = postURL("aHR0cDovL3Nlcmllbmp1bmtpZXMub3JnL21lZGlhL2FqYXgvc2VhcmNoL3NlYXJjaC5waHA=".decode('base64'), data={'string': "'" + query + "'"})
     try:
         sj = json.loads(sj)
     except:
@@ -91,9 +91,9 @@ def rate(title):
     if ".xvid." in title.lower():
         score -= 2
     if ".pal." in title.lower():
-        score -= 5
+        score -= 10
     if "dvd9" in title.lower():
-        score -= 5
+        score -= 10
     try:
         config = RssConfig('SJ')
         reject = config.get("rejectlist").replace(",", "|").lower() if len(
@@ -199,7 +199,7 @@ def dl_search(feed, title):
 
 def mb(link, jdownloaderpath):
     link = link.replace("+", "/")
-    url = getURL("http://movie-blog.org/" + link)
+    url = getURL("aHR0cDovL21vdmllLWJsb2cub3JnLw==".decode('base64') + link)
     rsscrawler = RssConfig('RSScrawler')
     config = RssConfig('MB')
     hoster = rsscrawler.get('hoster')
@@ -347,7 +347,7 @@ def mb(link, jdownloaderpath):
 
 # TODO: Add title to SJ_Serien
 def sj(id, jdownloaderpath):
-    url = getURL("http://serienjunkies.org/?cat=" + str(id))
+    url = getURL("aHR0cDovL3Nlcmllbmp1bmtpZXMub3JnLz9jYXQ9".decode('base64') + str(id))
     season_pool = re.findall(r'<h2>Staffeln:(.*?)<h2>Feeds', url).pop()
     season_links = re.findall(r'href="(.{1,125})">.{1,90}(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
     rsscrawler = RssConfig('RSScrawler')
@@ -402,6 +402,13 @@ def sj(id, jdownloaderpath):
         folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
         lq_pakete = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'\..*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
         lq_folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
+
+        if not pakete and not folgen and not lq_pakete and not lq_folgen:
+            sXX = sXX.replace("S0", "S")
+            pakete = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'\..*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
+            folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
+            lq_pakete = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'\..*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
+            lq_folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<(?:.*?\n.*?href="(.*?)".*? \| (.*)<|)'), url)
 
         best_matching_links = []
 

--- a/search.py
+++ b/search.py
@@ -317,6 +317,7 @@ def rate(title):
         score -= 3
     return score
 
+# TODO: Add title to SJ_Serien
 def sj(id, jdownloaderpath):
     url = getURL("http://serienjunkies.org/?cat=" + str(id))
     season_pool = re.findall(r'<h2>Staffeln:(.*?)<h2>Feeds', url).pop()
@@ -439,5 +440,4 @@ def sj(id, jdownloaderpath):
                 log_entry = '[Suche/Serie] - ' + dl_title + ' - <a href="' + dl_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + dl_title + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
                 logging.info(log_entry)
                 notify(log_entry)
-
     return True

--- a/search.py
+++ b/search.py
@@ -285,19 +285,29 @@ def rate(title):
     score = 0
     if ".bluray." in title.lower():
         score += 7
-    if re.match(r'.*?(4SJ|TVS).*?', title):
+    if ".bd." in title.lower():
+        score += 7
+    if ".bdrip." in title.lower():
+        score += 7
+    if re.match(r'.*\-(4SJ|TVS)', title):
         score += 4
     if ".dl." in title.lower():
         score += 2
-    if re.match(r'.*?(DTS|DD\+*51|DD\+*71|AC3\.5\.*1).*?', title):
+    if re.match(r'.*\.(DTS|DD\+*51|DD\+*71|AC3\.5\.*1)\..*', title):
+        score += 2
+    if re.match(r'.*\.(720|1080|2160)p\..*', title):
         score += 2
     if ".ml." in title.lower():
         score += 1
     if ".dd20." in title.lower():
         score += 1
-    if ".dubbed." in title.lower():
+    if "dubbed." in title.lower():
+        score -= 1
+    if ".synced." in title.lower():
         score -= 1
     if ".ac3d." in title.lower():
+        score -= 1
+    if ".dtsd." in title.lower():
         score -= 1
     if ".hdtv." in title.lower():
         score -= 1
@@ -312,16 +322,27 @@ def rate(title):
     if ".xvid." in title.lower():
         score -= 2
     if ".pal." in title.lower():
-        score -= 3
+        score -= 5
     if "dvd9" in title.lower():
-        score -= 3
+        score -= 5
+    try:
+        config = RssConfig('SJ')
+        reject = config.get("rejectlist").replace(",", "|").lower() if len(
+            config.get("rejectlist")) > 0 else r"^unmatchable$"
+    except TypeError:
+        reject = r"^unmatchable$"
+    r = re.search(reject, title.lower())
+    if r:
+        score -= 5
+    if ".subpack." in title.lower():
+        score -= 10
     return score
 
 # TODO: Add title to SJ_Serien
 def sj(id, jdownloaderpath):
     url = getURL("http://serienjunkies.org/?cat=" + str(id))
     season_pool = re.findall(r'<h2>Staffeln:(.*?)<h2>Feeds', url).pop()
-    season_links = re.findall(r'href="(.{1,90})">.{1,90}(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
+    season_links = re.findall(r'href="(.{1,125})">.{1,90}(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
     rsscrawler = RssConfig('RSScrawler')
 
     staffeln = []

--- a/search.py
+++ b/search.py
@@ -1,0 +1,272 @@
+import common
+from notifiers import notify
+from rssconfig import RssConfig
+from rssdb import RssDb
+from url import getURL
+from url import postURL
+
+from bs4 import BeautifulSoup as bs
+import feedparser
+import json
+import logging
+import re
+import os
+import sys
+
+def get(title):
+    query = title.replace(".", " ").replace(" ", "+")
+    mb = getURL("http://www.movie-blog.org/index.php?s=" + query)
+    mb = re.findall(r'post-.*?<a href="http:\/{2}.*?\/(.*?)" rel.*?>(.*?)<', mb)
+    print mb[1][0]
+    results = []
+    result_id = 0
+    for result in mb:
+        results.append([result_id, result[0].replace("/", "+"), result[1]])
+        result_id += 1
+    print str(results)
+    mb = results
+    sj = postURL("http://serienjunkies.org/media/ajax/search/search.php", data={'string': "'" + query + "'"})
+    sj = json.loads(sj)
+    return mb, sj
+
+def download_dl(title, jdownloaderpath, hoster, staffel, db, config):
+    search_title = title.replace(".German.720p.", ".German.DL.1080p.").replace(".German.DTS.720p.", ".German.DTS.DL.1080p.").replace(".German.AC3.720p.", ".German.AC3.DL.1080p.").replace(".German.AC3LD.720p.", ".German.AC3LD.DL.1080p.").replace(".German.AC3.Dubbed.720p.", ".German.AC3.Dubbed.DL.1080p.").split('.x264-', 1)[0].split('.h264-', 1)[0].replace(".", " ").replace(" ", "+")
+    search_url = "aHR0cDovL3d3dy5tb3ZpZS1ibG9nLm9yZy9zZWFyY2gv".decode('base64') + search_title + "/feed/rss2/"
+    feedsearch_title = title.replace(".German.720p.", ".German.DL.1080p.").replace(".German.DTS.720p.", ".German.DTS.DL.1080p.").replace(".German.AC3.720p.", ".German.AC3.DL.1080p.").replace(".German.AC3LD.720p.", ".German.AC3LD.DL.1080p.").replace(".German.AC3.Dubbed.720p.", ".German.AC3.Dubbed.DL.1080p.").split('.x264-', 1)[0].split('.h264-', 1)[0]
+    if not '.dl.' in feedsearch_title.lower():
+        logging.debug("%s - Release ignoriert (nicht zweisprachig, da wahrscheinlich nicht Retail)" %feedsearch_title)
+        return False
+    for (key, value, pattern) in dl_search(feedparser.parse(search_url), feedsearch_title):
+        download_link = False
+        req_page = getURL(value[0])
+        soup = bs(req_page, 'lxml')
+        download = soup.find("div", {"id": "content"})
+        url_hosters = re.findall(r'href="([^"\'>]*)".+?(.+?)<', str(download))
+        for url_hoster in url_hosters:
+            if not "bW92aWUtYmxvZy5vcmcv".decode("base64") in url_hoster[0]:
+                if hoster.lower() in url_hoster[1].lower():
+                    download_link = url_hoster[0]
+
+        if download_link:
+            if "aHR0cDovL3d3dy5tb3ZpZS1ibG9nLm9yZy8yMDEw".decode("base64") in download_link:
+                logging.debug("Fake-Link erkannt!")
+                return False
+            elif staffel:
+                common.write_crawljob_file(
+                    key,
+                    key,
+                    download_link,
+                    jdownloaderpath + "/folderwatch",
+                    "RSScrawler/Remux"
+                )
+                db.store(
+                    key,
+                    'dl' if config.get('enforcedl') and '.dl.' in key.lower() else 'added'
+                )
+                log_entry = '[Staffel] - <b>Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
+                logging.info(log_entry)
+                notify(log_entry)
+                return True
+            elif '.3d.' in key.lower():
+                retail = False
+                if config.get('cutoff'):
+                    if common.cutoff(key, '2'):
+                        retail = True
+                common.write_crawljob_file(
+                    key,
+                    key,
+                    download_link,
+                    jdownloaderpath + "/folderwatch",
+                    "RSScrawler/3Dcrawler"
+                )
+                db.store(
+                    key,
+                    'dl' if config.get('enforcedl') and '.dl.' in key.lower() else 'added'
+                )
+                log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + '3D/Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
+                logging.info(log_entry)
+                notify(log_entry)
+                return True
+            else:
+                retail = False
+                if config.get('cutoff'):
+                    if config.get('enforcedl'):
+                        if common.cutoff(key, '1'):
+                            retail = True
+                    else:
+                        if common.cutoff(key, '0'):
+                            retail = True
+                common.write_crawljob_file(
+                    key,
+                    key,
+                    download_link,
+                    jdownloaderpath + "/folderwatch",
+                    "RSScrawler/Remux"
+                )
+                db.store(
+                    key,
+                    'dl' if config.get('enforcedl') and '.dl.' in key.lower() else 'added'
+                )
+                log_entry = '[Film] - <b>' + ('Retail/' if retail else "") + 'Zweisprachig</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
+                logging.info(log_entry)
+                notify(log_entry)
+                return True
+
+def dl_search(feed, title):
+    s = re.sub(r"[&#\s/]", ".", title).lower()
+    for post in feed.entries:
+        found = re.search(s, post.title.lower())
+        if found:
+            yield (post.title, [post.link], title)
+
+def mb(link, jdownloaderpath):
+    link = link.replace("+", "/")
+    url = getURL("http://movie-blog.org/" + link)
+    rsscrawler = RssConfig('RSScrawler')
+    config = RssConfig('MB')
+    hoster = rsscrawler.get('hoster')
+    db = RssDb(os.path.join(os.path.dirname(sys.argv[0]), "Einstellungen/Downloads/Downloads.db"))
+
+    soup = bs(url, 'lxml')
+    download = soup.find("div", {"id": "content"})
+    key = re.findall(r'Permanent Link: (.*?)"', str(download)).pop()
+    url_hosters = re.findall(r'href="([^"\'>]*)".+?(.+?)<', str(download))
+    download_link = ""
+    for url_hoster in url_hosters:
+        if not "bW92aWUtYmxvZy5vcmcv".decode("base64") in url_hoster[0]:
+            if hoster.lower() in url_hoster[1].lower():
+                download_link = url_hoster[0]
+
+    englisch = False
+    if "*englisch*" in key.lower():
+        key = key.replace('*ENGLISCH*', '').replace("*Englisch*", "")
+        englisch = True
+
+    staffel = re.search(r"s\d{1,2}(-s\d{1,2}|-\d{1,2}|\.)", key.lower())
+
+    if config.get('enforcedl') and '.dl.' not in key.lower():
+        original_language = ""
+        fail = False
+        get_imdb_url = url
+        key_regex = r'<title>' + re.escape(key) + r'.*?<\/title>\n.*?<link>(?:(?:.*?\n){1,25}).*?[mM][kK][vV].*?(?:|href=.?http(?:|s):\/\/(?:|www\.)imdb\.com\/title\/(tt[0-9]{7,9}).*?)[iI][mM][dD][bB].*?(?!\d(?:\.|\,)\d)(?:.|.*?)<\/a>'
+        imdb_id = re.findall(key_regex, get_imdb_url)
+        if len(imdb_id) > 0:
+            if not imdb_id[0]:
+                fail = True
+            else:
+                imdb_id = imdb_id[0]
+        else:
+            fail = True
+        if fail:
+            search_title = re.findall(r"(.*?)(?:\.(?:(?:19|20)\d{2})|\.German|\.\d{3,4}p|\.S(?:\d{1,3})\.)", key)[0].replace(".", "+")
+            search_url = "http://www.imdb.com/find?q=" + search_title
+            search_page = getURL(search_url)
+            search_results = re.findall(r'<td class="result_text"> <a href="\/title\/(tt[0-9]{7,9})\/\?ref_=fn_al_tt_\d" >(.*?)<\/a>.*? \((\d{4})\)..(.{9})', search_page)
+            total_results = len(search_results)
+            if total_results == 0:
+                download_imdb = ""
+            elif staffel:
+                imdb_id = search_results[0][0]
+            else:
+                no_series = False
+                while total_results > 0:
+                    attempt = 0
+                    for result in search_results:
+                        if result[3] == "TV Series":
+                            no_series = False
+                            total_results -= 1
+                            attempt += 1
+                        else:
+                            no_series = True
+                            imdb_id = search_results[attempt][0]
+                            total_results = 0
+                            break
+                if no_series is False:
+                    logging.debug("%s - Keine passende Film-IMDB-Seite gefunden" % key)
+        if not imdb_id:
+            if not download_dl(key, jdownloaderpath, hoster, staffel, db, config):
+                logging.debug("%s - Kein zweisprachiges Release gefunden." % key)
+        else:
+            if isinstance(imdb_id, list):
+                imdb_id = imdb_id.pop()
+            imdb_url = "http://www.imdb.com/title/" + imdb_id
+            details = getURL(imdb_url)
+            if not details:
+                logging.debug("%s - Originalsprache nicht ermittelbar" % key)
+            original_language = re.findall(r"Language:<\/h4>\n.*?\n.*?url'>(.*?)<\/a>", details)
+            if original_language:
+                original_language = original_language[0]
+            if original_language == "German":
+                logging.debug("%s - Originalsprache ist Deutsch. Breche Suche nach zweisprachigem Release ab!" % key)
+            else:
+                if not download_dl(key, jdownloaderpath, hoster, staffel, db, config) and not englisch:
+                    logging.debug("%s - Kein zweisprachiges Release gefunden! Breche ab." % key)
+
+    if download_link:
+        if staffel:
+            common.write_crawljob_file(
+                key,
+                key,
+                download_link,
+                jdownloaderpath + "/folderwatch",
+                "RSScrawler"
+            )
+            db.store(
+                key.replace(".COMPLETE", "").replace(".Complete", ""),
+                'notdl' if config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
+            )
+            log_entry = '[Suche/Staffel] - ' + key.replace(".COMPLETE.", ".") + ' - [<a href="' + download_link + '" target="_blank">Link</a>]'
+            logging.info(log_entry)
+            notify(log_entry)
+            return True
+        elif '.3d.' in key.lower():
+            retail = False
+            if config.get('cutoff') and '.COMPLETE.' not in key.lower():
+                if config.get('enforcedl'):
+                    if common.cutoff(key, '2'):
+                        retail = True
+            common.write_crawljob_file(
+                key,
+                key,
+                download_link,
+                jdownloaderpath + "/folderwatch",
+                "RSScrawler"
+            )
+            db.store(
+                key,
+                'notdl' if config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
+            )
+            log_entry = '[Suche/Film] - <b>' + ('Retail/' if retail else "") + '3D</b> - ' + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
+            logging.info(log_entry)
+            notify(log_entry)
+            return True
+        else:
+            retail = False
+            if config.get('cutoff') and '.COMPLETE.' not in key.lower():
+                if config.get('enforcedl'):
+                    if common.cutoff(key, '1'):
+                        retail = True
+                else:
+                    if common.cutoff(key, '0'):
+                        retail = True
+            common.write_crawljob_file(
+                key,
+                key,
+                download_link,
+                jdownloaderpath + "/folderwatch",
+                "RSScrawler"
+            )
+            db.store(
+                key,
+                'notdl' if config.get('enforcedl') and '.dl.' not in key.lower() else 'added'
+            )
+            log_entry = '[Suche/Film] - ' + ('<b>Englisch</b> - ' if englisch and not retail else "") + ('<b>Englisch/Retail</b> - ' if englisch and retail else "") + ('<b>Retail</b> - ' if not englisch and retail else "") + key + ' - <a href="' + download_link + '" target="_blank" title="Link &ouml;ffnen"><i class="fas fa-link"></i></a> <a href="#log" ng-click="resetTitle(&#39;' + key + '&#39;)" title="Download f&uuml;r n&auml;chsten Suchlauf zur&uuml;cksetzen"><i class="fas fa-undo"></i></a>'
+            logging.info(log_entry)
+            notify(log_entry)
+            return True
+    else:
+        return False
+
+def sj(id, jdownloaderpath):
+    url = getURL("http://serienjunkies.org/?cat=" + str(id))
+    return url

--- a/search.py
+++ b/search.py
@@ -13,6 +13,7 @@ import re
 import os
 import sys
 import time
+import StringIO
 
 def get(title):
     config = RssConfig('MB')
@@ -345,12 +346,24 @@ def mb(link, jdownloaderpath):
     else:
         return False
 
-# TODO: Add title to SJ_Serien
 def sj(id, jdownloaderpath):
     url = getURL("aHR0cDovL3Nlcmllbmp1bmtpZXMub3JnLz9jYXQ9".decode('base64') + str(id))
     season_pool = re.findall(r'<h2>Staffeln:(.*?)<h2>Feeds', url).pop()
     season_links = re.findall(r'href="(.{1,125})">.{1,90}(Staffel|Season).*?(\d{1,2}-?\d{1,2}|\d{1,2})', season_pool)
+    title = re.findall(r'>(.{1,90}?) &#', season_pool).pop()
+
     rsscrawler = RssConfig('RSScrawler')
+
+    if os.path.isfile(os.path.join(os.path.dirname(sys.argv[0]), 'Einstellungen/Listen/SJ_Serien.txt')):
+        file = open(os.path.join(os.path.dirname(sys.argv[0]), 'Einstellungen/Listen/SJ_Serien.txt'))
+        output = StringIO.StringIO()
+        for line in file.readlines():
+            output.write(line.replace("XXXXXXXXXX",""))
+    liste = output.getvalue()
+    if not title in liste:
+        with open(os.path.join(os.path.dirname(sys.argv[0]), 'Einstellungen/Listen/SJ_Serien.txt'), 'wb') as f:
+            liste = liste + "\n" + title
+            f.write(liste.encode('utf-8'))
 
     staffeln = []
     staffel_nr = []

--- a/search.py
+++ b/search.py
@@ -20,16 +20,27 @@ def get(title):
     query = title.replace(".", " ").replace(" ", "+")
     mb = getURL("http://www.movie-blog.org/index.php?s=" + query + "+" + quality)
     mb = re.findall(r'post-.*?<a href="http:\/{2}.*?\/(.*?)" rel.*?>(.*?)<', mb)
-    results = []
+    results = {}
+    i = 0
     for result in mb:
         if not result[1].endswith("-MB") and not result[1].endswith(".MB"):
-            results.append([result[0].replace("/", "+"), result[1]])
+            res = {"link": result[0].replace("/", "+"), "title": result[1]}
+            results["result" + str(i)] = res
+            i += 1
     mb = results
+
+    results = {}
+    i = 0
     sj = postURL("http://serienjunkies.org/media/ajax/search/search.php", data={'string': "'" + query + "'"})
     try:
         sj = json.loads(sj)
     except:
         sj = []
+    for result in sj:
+        res = {"id": result[0], "title": result[1]}
+        results["result" + str(i)] = res
+        i += 1
+    sj = results
     return mb, sj
 
 def download_dl(title, jdownloaderpath, hoster, staffel, db, config):

--- a/search.py
+++ b/search.py
@@ -116,7 +116,7 @@ def dl_search(feed, title):
         if found:
             yield (post.title, [post.link], title)
 
-# TODO Ignore/Resolution
+# TODO Resolution
 def mb(link, jdownloaderpath):
     link = link.replace("+", "/")
     url = getURL("http://movie-blog.org/" + link)
@@ -344,48 +344,59 @@ def sj(id, jdownloaderpath):
     for sXX, link in found_seasons.items():
         config = RssConfig('SJ')
         quality = config.get('quality')
-        try:
-            reject = config.get("rejectlist").replace(",", "|").lower() if len(config.get("rejectlist")) > 0 else "^unmatchable$"
-        except TypeError:
-            reject = "^unmatchable$"
-
         url = getURL(link)
         pakete = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'\..*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
-        folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,2,3}\..*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
+        folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?' + quality + r'.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
         lq_pakete = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'\..*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
-        lq_folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,2,3}\..*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
+        lq_folgen = re.findall(re.compile(r'<p><strong>(.*?\.' + sXX + r'E\d{1,3}.*?)<.*?\n.*?href="(.*?)".*? \| (.*)<.*?\n.*?href="(.*?)".*? \| (.*)<'), url)
+        # add highest scoring items to list (multiple with same score possible!)
+
+        best_matching_links = []
 
         if pakete:
+            links = []
             for x in pakete:
                 title = x[0].replace("Staffelpack ", "")
-                ok = re.search(reject, title.lower())
-                if ok:
-                    score = rate(title)
-                    hoster = [[x[2], x[1]], [x[4], x[3]]]
-                    print title + " score: " + str(score)
+                score = rate(title)
+                hoster = [[x[2], x[1]], [x[4], x[3]]]
+                links.append([score, title, hoster])
+            highest_score = sorted(links, reverse=True)[0][0]
+            for l in links:
+                if l[0] == highest_score:
+                    best_matching_links.append([l[1], l[2]])
         elif folgen:
+            links = []
             for x in folgen:
                 title = x[0].replace("Staffelpack ", "")
-                ok = re.search(reject, title.lower())
-                if ok:
-                    score = rate(title)
-                    hoster = [[x[2], x[1]], [x[4], x[3]]]
-                    print title + " score: " + str(score)
+                score = rate(title)
+                hoster = [[x[2], x[1]], [x[4], x[3]]]
+                links.append([score, title, hoster])
+            highest_score = sorted(links, reverse=True)[0][0]
+            for l in links:
+                if l[0] == highest_score:
+                    best_matching_links.append([l[1], l[2]])
         elif lq_pakete:
+            links = []
             for x in lq_pakete:
                 title = x[0].replace("Staffelpack ", "")
-                ok = re.search(reject, title.lower())
-                if ok:
-                    score = rate(title)
-                    hoster = [[x[2], x[1]], [x[4], x[3]]]
-                    print title + " score: " + str(score)
+                score = rate(title)
+                hoster = [[x[2], x[1]], [x[4], x[3]]]
+                links.append([score, title, hoster])
+            highest_score = sorted(links, reverse=True)[0][0]
+            for l in links:
+                if l[0] == highest_score:
+                    best_matching_links.append([l[1], l[2]])
         elif lq_folgen:
+            links = []
             for x in lq_folgen:
                 title = x[0].replace("Staffelpack ", "")
-                ok = re.search(reject, title.lower())
-                if ok:
-                    score = rate(title)
-                    hoster = [[x[2], x[1]], [x[4], x[3]]]
-                    print title + " score: " + str(score)
+                score = rate(title)
+                hoster = [[x[2], x[1]], [x[4], x[3]]]
+                links.append([score, title, hoster])
+            highest_score = sorted(links, reverse=True)[0][0]
+            for l in links:
+                if l[0] == highest_score:
+                    best_matching_links.append([l[1], l[2]])
+        print str(best_matching_links)
 
     return True

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 # https://github.com/rix1337/RSScrawler/issues/88#issuecomment-251078409
 # https://github.com/rix1337/RSScrawler/issues/7#issuecomment-271187968
 
-VERSION="v.4.0.5"
+VERSION="v.4.0.6"
 echo "┌────────────────────────────────────────────────────────┐"
 echo "  Programminfo:    RSScrawler $VERSION von RiX"
 echo "  Projektseite:    https://github.com/rix1337/RSScrawler"

--- a/url.py
+++ b/url.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# RSScrawler
+# Projekt von https://github.com/rix1337
+
+import cfscrape
+
+from rssconfig import RssConfig
+
+def getURL(url):
+    proxy = RssConfig('RSScrawler').get('proxy')
+    if proxy:
+        proxies = []
+        if proxy.startswith('http://'):
+            proxies[0] = proxy[:4]
+            proxies[1] = proxy
+        elif proxy.startswith('https://'):
+            proxies[0] = proxy[:5]
+            proxies[1] = proxy
+        elif proxy.startswith('socks5://'):
+            proxies[0] = 'http'
+            proxies[1] = proxy
+        proxies = {proxies[0]: proxies[1]}
+        scraper = cfscrape.create_scraper(delay=10, proxies=proxies)
+    else:
+        scraper = cfscrape.create_scraper(delay=10)
+    return scraper.get(url).content
+
+def postURL(url, data):
+    proxy = RssConfig('RSScrawler').get('proxy')
+    if proxy:
+        proxies = []
+        if proxy.startswith('http://'):
+            proxies[0] = proxy[:4]
+            proxies[1] = proxy
+        elif proxy.startswith('https://'):
+            proxies[0] = proxy[:5]
+            proxies[1] = proxy
+        elif proxy.startswith('socks5://'):
+            proxies[0] = 'http'
+            proxies[1] = proxy
+        proxies = {proxies[0]: proxies[1]}
+        scraper = cfscrape.create_scraper(delay=10, proxies=proxies)
+    else:
+        scraper = cfscrape.create_scraper(delay=10)
+    return scraper.post(url, data).content

--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@ def getVersion():
 def updateCheck():
     localversion = getVersion()
     try:
-        onlineversion = re.search('return "(v\.\d{1,2}\.\d{1,2}\.\d{1,2})"', urllib2.urlopen('https://raw.githubusercontent.com/rix1337/RSScrawler/master/version.py').read()).group(1)
+        onlineversion = re.search(r'return "(v\.\d{1,2}\.\d{1,2}\.\d{1,2})"', urllib2.urlopen('https://raw.githubusercontent.com/rix1337/RSScrawler/master/version.py').read()).group(1)
         if localversion == onlineversion:
             return (False, localversion)
         else:

--- a/version.py
+++ b/version.py
@@ -7,7 +7,7 @@ import urllib2
 
 
 def getVersion():
-    return "v.4.0.5"
+    return "v.4.0.6"
 
 def updateCheck():
     localversion = getVersion()

--- a/web.py
+++ b/web.py
@@ -2,6 +2,7 @@ from flask import Flask, request, send_from_directory, render_template, jsonify
 
 from rssconfig import RssConfig
 from rssdb import RssDb
+import search
 import files
 import version
 
@@ -317,6 +318,41 @@ def delete_title(title):
     else:
         return "Failed", 405
 
+@app.route(prefix + "/api/search/<title>", methods=['GET'])
+def search_title(title):
+    if request.method == 'GET':
+        results = search.get(title)
+        return jsonify(
+            {
+                "results": {
+                    "mb": results[0],
+                    "sj": results[1]
+                }
+            }
+        ), 200
+    else:
+        return "Failed", 405
+
+@app.route(prefix + "/api/download_mb/<permalink>", methods=['GET'])
+def download_mb(permalink):
+    if request.method == 'GET':
+        if search.mb(permalink, jdpath):
+            return "Success", 200
+        else:
+            return "Failed", 400
+    else:
+        return "Failed", 40
+
+@app.route(prefix + "/api/download_sj/<id>", methods=['GET'])
+def download_sj(id):
+    if request.method == 'GET':
+        if search.sj(id, jdpath):
+            return "Success", 200
+        else:
+            return "Failed", 400
+    else:
+        return "Failed", 405
+
 @app.route(prefix + "/api/lists/", methods=['GET', 'POST'])
 def get_post_lists():
     if request.method == 'GET':
@@ -375,9 +411,11 @@ def getListe(liste):
             output.write(line.replace("XXXXXXXXXX",""))
     return output.getvalue()
 
-def start(port, docker_arg):
+def start(port, docker_arg, jd):
     global docker
     docker = docker_arg
+    global jdpath
+    jdpath = jd
     if version.updateCheck()[0]:
         updateversion = version.updateCheck()[1]
         print('Update steht bereit (' + updateversion +')! Weitere Informationen unter https://github.com/rix1337/RSScrawler/releases/latest')

--- a/web.py
+++ b/web.py
@@ -333,9 +333,9 @@ def search_title(title):
     else:
         return "Failed", 405
 
-@app.route(prefix + "/api/download_mb/<permalink>", methods=['GET'])
+@app.route(prefix + "/api/download_mb/<permalink>", methods=['POST'])
 def download_mb(permalink):
-    if request.method == 'GET':
+    if request.method == 'POST':
         if search.mb(permalink, jdpath):
             return "Success", 200
         else:
@@ -343,9 +343,9 @@ def download_mb(permalink):
     else:
         return "Failed", 40
 
-@app.route(prefix + "/api/download_sj/<id>", methods=['GET'])
+@app.route(prefix + "/api/download_sj/<id>", methods=['POST'])
 def download_sj(id):
-    if request.method == 'GET':
+    if request.method == 'POST':
         if search.sj(id, jdpath):
             return "Success", 200
         else:

--- a/web/index.html
+++ b/web/index.html
@@ -21,8 +21,8 @@
         <form>
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
-                <a href="#search" ng-click="showSearch()"  style="display: none;" class="results btn btn-dark" type="submit">Zurück</a>
-                <input ng-model="search" class="search form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search" data-toggle="tooltip" data-placement="top" title="Bequeme, intelligente, Suchfunktion. Hier werden komplette Serien(!) und Titel gesucht. Komplette Serien landen auch in der Suchliste. Die Auflösung und die Filterliste werden berücksichtigt, aber nicht forciert.">
+                <a href="#search" ng-click="showSearch()"  style="display: none;" class="results btn btn-danger" type="submit">Zurück</a>
+                <input ng-model="search" class="search form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search" data-toggle="tooltip" data-placement="top" title="Bequeme Suchfunktion für komplette Serien(!), Filme und andere verfügbare Titel. Komplette Serien landen auch in der Suchliste. Die jeweilige Auflösung und die Filterliste werden berücksichtigt, aber nicht forciert. Bereits geladene Releases werden hier bewusst ignoriert!">
                 <p class="results" data-ng-repeat="x in results.sj"><a href="#search" ng-click="downloadSJ(x.id)" class="btn btn-info" type="submit"><i class="fas fa-download"></i> Komplette Serie: <span ng-bind="x.title"></span></a></p>
                 <p class="results" data-ng-repeat="y in results.mb"><a href="#search" ng-click="downloadMB(y.link)" class="btn btn-secondary" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.title"></span></a></p>
                 <a href="#search" ng-click="searchNow()" class="search btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>

--- a/web/index.html
+++ b/web/index.html
@@ -22,8 +22,9 @@
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
                 <input ng-model="search" class="form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search">
-                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB({{x}})" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i><input ng-model="x.link"></input><input ng-model="x.title"></input> {{x}} herunterladen</a></p>
-                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadMB({{x}})" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i><input ng-model="y.id"></input><input ng-model="y.title"></input> {{x}} herunterladen</a></p>
+                <!-- TODO bind x/y.link to downloadMB/SJ-->
+                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB(link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="x.link"></span> | <span ng-bind="x.title"></span></a></p>
+                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadSJ(link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.id"></span> | <span ng-bind="y.title"></span></a></p>
                 <a href="#search" ng-click="searchNow()" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
             </div>
         </form>

--- a/web/index.html
+++ b/web/index.html
@@ -22,8 +22,8 @@
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
                 <input ng-model="search" class="form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search">
-                <textarea ng-model="results_mb" class="log form-control"></textarea>
-                <textarea ng-model="results_sj" class="log form-control"></textarea>
+                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB({{x}})" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i><input ng-model="x.link"></input><input ng-model="x.title"></input> {{x}} herunterladen</a></p>
+                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadMB({{x}})" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i><input ng-model="y.id"></input><input ng-model="y.title"></input> {{x}} herunterladen</a></p>
                 <a href="#search" ng-click="searchNow()" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
             </div>
         </form>

--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,16 @@
             <p id="headtitle">Projekt von <a href="https://github.com/rix1337/RSScrawler/commits" target="_blank">RiX</a><span id="updateready" style="display: none;"> - Update verfügbar!</span></p>
         </div>
 
+        <form>
+            <div name="search" id="search" class="container app col">
+                <h1><i class="fas fa-search"></i> Suchen</h1>
+                <input ng-model="search" class="form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search">
+                <textarea ng-model="results_mb" class="log form-control"></textarea>
+                <textarea ng-model="results_sj" class="log form-control"></textarea>
+                <a href="#search" ng-click="searchNow()" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
+            </div>
+        </form>
+
         <div name="log" id="log" class="container app col">
            <h1><i class="fas fa-history"></i> Log</h1>
            <div bind-html-compile="log" class="log form-control"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
                 <a href="#search" ng-click="showSearch()"  style="display: none;" class="results btn btn-dark" type="submit">Zurück</a>
-                <input ng-model="search" class="search form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search" data-toggle="tooltip" data-placement="top" title="XXX">
+                <input ng-model="search" class="search form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search" data-toggle="tooltip" data-placement="top" title="Bequeme, intelligente, Suchfunktion. Hier werden komplette Serien(!) und Titel gesucht. Komplette Serien landen auch in der Suchliste. Die Auflösung und die Filterliste werden berücksichtigt, aber nicht forciert.">
                 <p class="results" data-ng-repeat="x in results.sj"><a href="#search" ng-click="downloadSJ(x.id)" class="btn btn-info" type="submit"><i class="fas fa-download"></i> Komplette Serie: <span ng-bind="x.title"></span></a></p>
                 <p class="results" data-ng-repeat="y in results.mb"><a href="#search" ng-click="downloadMB(y.link)" class="btn btn-secondary" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.title"></span></a></p>
                 <a href="#search" ng-click="searchNow()" class="search btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>

--- a/web/index.html
+++ b/web/index.html
@@ -22,9 +22,8 @@
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
                 <input ng-model="search" class="form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search">
-                <!-- TODO bind x/y.link to downloadMB/SJ-->
-                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB(link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="x.link"></span> | <span ng-bind="x.title"></span></a></p>
-                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadSJ(link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.id"></span> | <span ng-bind="y.title"></span></a></p>
+                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB(x.link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="x.title"></span></a></p>
+                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadSJ(y.id)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.title"></span></a></p>
                 <a href="#search" ng-click="searchNow()" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
             </div>
         </form>

--- a/web/index.html
+++ b/web/index.html
@@ -21,10 +21,11 @@
         <form>
             <div name="search" id="search" class="container app col">
                 <h1><i class="fas fa-search"></i> Suchen</h1>
-                <input ng-model="search" class="form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search">
-                <p data-ng-repeat="x in results.mb"><a href="#search" ng-click="downloadMB(x.link)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="x.title"></span></a></p>
-                <p data-ng-repeat="y in results.sj"><a href="#search" ng-click="downloadSJ(y.id)" class="btn btn-dark" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.title"></span></a></p>
-                <a href="#search" ng-click="searchNow()" class="btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
+                <a href="#search" ng-click="showSearch()"  style="display: none;" class="results btn btn-dark" type="submit">Zurück</a>
+                <input ng-model="search" class="search form-control mr-sm-2" type="search" placeholder="Filme und Serien suchen" aria-label="Search" data-toggle="tooltip" data-placement="top" title="XXX">
+                <p class="results" data-ng-repeat="x in results.sj"><a href="#search" ng-click="downloadSJ(x.id)" class="btn btn-info" type="submit"><i class="fas fa-download"></i> Komplette Serie: <span ng-bind="x.title"></span></a></p>
+                <p class="results" data-ng-repeat="y in results.mb"><a href="#search" ng-click="downloadMB(y.link)" class="btn btn-secondary" type="submit"><i class="fas fa-download"></i> <span ng-bind="y.title"></span></a></p>
+                <a href="#search" ng-click="searchNow()" class="search btn btn-dark" type="submit"><i id="spinner-search" style="display: none;" class="fas fa-sync fa-spin"></i> Suchen</a>
             </div>
         </form>
 

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -250,8 +250,8 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
             console.log('Nach ' + title + ' gesucht!');
             getLogOnly();
         }, function (res) {
-            console.log('Konnte Download von ' + title + ' nicht zurück setzen!');
-            showDanger('Konnte Download von ' + title + ' nicht zurück setzen!');
+            console.log('Konnte ' + title + ' nicht suchen!');
+            showDanger('Konnte  ' + title + ' nicht suchen!');
         });
     };
 

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -21,6 +21,19 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         $('[data-toggle="tooltip"]').tooltip()
     })
 
+    $scope.results = [
+        {
+         mb: {
+             link: "Link",
+             title: "Title"
+         },
+         sj: {
+             id: "Link",
+             title: "Title",
+         }
+        }
+    ]
+
     $scope.bools = [
         {value: true, label: 'Aktiviert'},
         {value: false, label: 'Deaktiviert'},
@@ -58,6 +71,14 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         searchNow();
     };
 
+    $scope.downloadMB = function(link) {
+        downloadMB(link);
+    };
+
+    $scope.downloadSJ = function(id) {
+        downloadSJ(id);
+    };
+
     $scope.resetTitle = function(title) {
         resetTitle(title);
     };
@@ -69,8 +90,6 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
     $scope.saveSettings = function() {
         setSettings();
     };
-
-    // TODO create downloadMB/SJ in scope, then inside rsscrawler.js - > bound to /api/download_mb/sj -> change method to post if successful
 
     function getAll() {
         $http.get('api/all/')
@@ -178,6 +197,28 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
             $('#headingTwoOne').addClass('show');
             console.log('Konnte Einstellungen nicht speichern!');
             showDanger('Konnte Einstellungen nicht speichern!');
+        });
+    };
+
+    function downloadMB(link) {
+        $http.post('api/download_mb/' + link)
+        .then(function(res){
+            console.log('Download gestartet!');
+            showSuccess('Download gestartet!');
+        }, function (res) {
+            console.log('Konnte Download nicht starten!');
+            showDanger('Konnte Download nicht starten!');
+        });
+    };
+
+    function downloadSJ(id) {
+        $http.post('api/download_sj/' + id)
+        .then(function(res){
+            console.log('Download gestartet!');
+            showSuccess('Download gestartet!');
+        }, function (res) {
+            console.log('Konnte Download nicht starten!');
+            showDanger('Konnte Download nicht starten!');
         });
     };
 

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -70,6 +70,8 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         setSettings();
     };
 
+    // TODO create downloadMB/SJ in scope, then inside rsscrawler.js - > bound to /api/download_mb/sj -> change method to post if successful
+
     function getAll() {
         $http.get('api/all/')
         .then(function(res){

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -63,6 +63,10 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
 
     $scope.init = getAll();
 
+    $scope.showSearch = function() {
+        showSearch();
+    };
+
     $scope.deleteLog = function() {
         deleteLog();
     };
@@ -241,12 +245,19 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         $http.get('api/search/' + title)
         .then(function(res){
             $scope.results = res.data.results;
+            $(".results").show();
+            $(".search").hide();
             console.log('Nach ' + title + ' gesucht!');
             getLogOnly();
         }, function (res) {
             console.log('Konnte Download von ' + title + ' nicht zurück setzen!');
             showDanger('Konnte Download von ' + title + ' nicht zurück setzen!');
         });
+    };
+
+    function showSearch() {
+        $('.results').hide();
+        $('.search').show();
     };
 
     function resetTitle(title) {

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -1,4 +1,5 @@
-app = angular.module('crwlApp', [])  .directive('bindHtmlCompile', function($compile) {
+app = angular.module('crwlApp', [])
+    .directive('bindHtmlCompile', function($compile) {
     return {
       restrict: "A",
       scope: {
@@ -51,6 +52,10 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
 
     $scope.deleteLog = function() {
         deleteLog();
+    };
+
+    $scope.searchNow = function() {
+        searchNow();
     };
 
     $scope.resetTitle = function(title) {
@@ -187,6 +192,21 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         });
     };
 
+    function searchNow() {
+        spinSearch();
+        title = $scope.search
+        $http.get('api/search/' + title)
+        .then(function(res){
+            $scope.results_mb = res.data.results.mb;
+            $scope.results_sj = res.data.results.sj;
+            console.log('Nach ' + title + ' gesucht!');
+            getLogOnly();
+        }, function (res) {
+            console.log('Konnte Download von ' + title + ' nicht zurück setzen!');
+            showDanger('Konnte Download von ' + title + ' nicht zurück setzen!');
+        });
+    };
+
     function resetTitle(title) {
         $http.delete('api/delete/' + title)
         .then(function(res){
@@ -225,6 +245,9 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         $(".alert-danger").fadeTo(5000, 500).slideUp(500, function(){
             $(".alert-danger").slideUp(500);
         });
+    };
+    function spinSearch() {
+        $("#spinner-search").fadeIn().delay(1000).fadeOut();
     };
 
     function spinLog() {

--- a/web/js/rsscrawler.js
+++ b/web/js/rsscrawler.js
@@ -197,8 +197,7 @@ app.controller('crwlCtrl', function($scope, $http, $timeout){
         title = $scope.search
         $http.get('api/search/' + title)
         .then(function(res){
-            $scope.results_mb = res.data.results.mb;
-            $scope.results_sj = res.data.results.sj;
+            $scope.results = res.data.results;
             console.log('Nach ' + title + ' gesucht!');
             getLogOnly();
         }, function (res) {


### PR DESCRIPTION
Auf MB werden alle passenden Ergebnisse (inkl der gesetzten Auflösung) gezeigt. Auf SJ werden alle passenden Serientitel gezeigt.
Beim Download lädt MB den entsprechenden Eintrag (unspektakulär). Der SJ-Download geht allerdings wirklich in die Tiefe:
-Alle verfügbaren Staffeln werden erfasst und (wenn englisch erlaubt) auch um Englischsprachige ergänzt. Dadurch erhält man auf einen Schlag alle verfügbaren Staffeln einer Serie
-Die Staffelseiten werden zunächst nach kompletten Paketen und Ersatzweise nach einzelepisoden durchsucht
-Alle gefundenen Titel werden dann durch ein Scoringsystem bewertet & die besten Treffer pro Staffel werden geaddet

Dadurch wird idR ein Release aus bestmöglicher Quelle (Bluray first, TV last), passend zur gewünschten Quali (wenns dafür nichts gibt, nimmt es das nächst bessere) gesucht. Gibt es mehrere zur Quali wird nach Gruppe (4sj/tvs), mehreren audiospuren, mehreren audiokanälen gerankt; grütze (xvid, etc) wird abgestraft.

Am Ende wird dadurch extrem schnell für jede gewünschte Serie jede Staffel optimal geladen.