### PR TITLE
v.4.2.7 - Füge nur Releases mit MKV hinzu / Erzwinge DL auch bei CDC / Erkenne Retail ohne "DL"

### DIFF
--- a/RSScrawler.py
+++ b/RSScrawler.py
@@ -774,6 +774,7 @@ class BL:
         self.i_hw_done = False
         self.mb_done = False
         self.hw_done = False
+        self.dl_unsatisfied = False
 
         try:
             self.imdb = float(self.config.get('imdb'))
@@ -827,122 +828,123 @@ class BL:
                 found = re.search(s, post.title.lower())
                 if found:
                     content = post.content[0].value.encode("utf8")
-                    found = re.search(ignore, post.title.lower())
-                    if found:
-                        self.log_debug(
-                            "%s - Release ignoriert (basierend auf ignore-Einstellung)" % post.title)
-                        continue
-                    if rsscrawler.get("surround"):
-                        if not re.match(r'.*\.(DTS|DD\+*51|DD\+*71|AC3\.5\.*1)\..*', post.title):
-                            self.log_debug(
-                                post.title + " - Release ignoriert (kein Mehrkanalton)")
-                            continue
-                    ss = self.allInfos[key][0].lower()
-                    if self.filename == 'MB_Filme':
-                        if ss == "480p":
-                            if "720p" in post.title.lower() or "1080p" in post.title.lower() or "1080i" in post.title.lower() or "2160p" in post.title.lower():
-                                continue
-                            found = True
-                        else:
-                            found = re.search(ss, post.title.lower())
+                    if re.search(r'.*([mM][kK][vV]).*', content):
+                        found = re.search(ignore, post.title.lower())
                         if found:
-                            sss = r"[\.-]+" + self.allInfos[key][1].lower()
-                            found = re.search(sss, post.title.lower())
-                            if self.allInfos[key][2]:
-                                found = all([word in post.title.lower()
-                                             for word in self.allInfos[key][2]])
-                            if found:
-                                episode = re.search(
-                                    r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
-                                if episode:
-                                    self.log_debug(
-                                        "%s - Release ignoriert (Serienepisode)" % post.title)
-                                    continue
-                                yield (post.title, content, key)
-                    elif self.filename == 'MB_3D':
-                        if '.3d.' in post.title.lower():
-                            if self.config.get('crawl3d') and (
-                                    "1080p" in post.title.lower() or "1080i" in post.title.lower()):
-                                if not self.config.get("crawl3dtype"):
-                                    c3d_type = "hsbs"
-                                else:
-                                    c3d_type = self.config.get("crawl3dtype")
-                                if c3d_type == "hsbs":
-                                    if re.match(r'.*\.(H-OU|HOU)\..*', post.title):
-                                        self.log_debug(
-                                            "%s - Release ignoriert (Falsches 3D-Format)" % post.title)
-                                        continue
-                                elif c3d_type == "hou":
-                                    if not re.match(r'.*\.(H-OU|HOU)\..*', post.title):
-                                        self.log_debug(
-                                            "%s - Release ignoriert (Falsches 3D-Format)" % post.title)
-                                        continue
-                                found = True
-                            else:
-                                continue
-                        if found:
-                            sss = r"[\.-]+" + self.allInfos[key][1].lower()
-                            found = re.search(sss, post.title.lower())
-                            if self.allInfos[key][2]:
-                                found = all([word in post.title.lower()
-                                             for word in self.allInfos[key][2]])
-                            if found:
-                                episode = re.search(
-                                    r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
-                                if episode:
-                                    self.log_debug(
-                                        "%s - Release ignoriert (Serienepisode)" % post.title)
-                                    continue
-                                yield (post.title, content, key)
-
-                    elif self.filename == 'MB_Staffeln':
-                        validsource = re.search(self.config.get(
-                            "seasonssource"), post.title.lower())
-                        if not validsource:
                             self.log_debug(
-                                post.title + " - Release hat falsche Quelle")
+                                "%s - Release ignoriert (basierend auf ignore-Einstellung)" % post.title)
                             continue
-                        if not ".complete." in post.title.lower():
-                            self.log_debug(
-                                post.title + " - Staffel noch nicht komplett")
-                            continue
-                        season = re.search(r"\.s\d", post.title.lower())
-                        if not season:
-                            self.log_debug(
-                                post.title + " - Release ist keine Staffel")
-                            continue
-                        if not self.config.get("seasonpacks"):
-                            staffelpack = re.search(
-                                r"s\d.*(-|\.).*s\d", post.title.lower())
-                            if staffelpack:
+                        if rsscrawler.get("surround"):
+                            if not re.match(r'.*\.(DTS|DD\+*51|DD\+*71|AC3\.5\.*1)\..*', post.title):
                                 self.log_debug(
-                                    "%s - Release ignoriert (Staffelpaket)" % post.title)
+                                    post.title + " - Release ignoriert (kein Mehrkanalton)")
                                 continue
                         ss = self.allInfos[key][0].lower()
-
-                        if ss == "480p":
-                            if "720p" in post.title.lower() or "1080p" in post.title.lower() or "1080i" in post.title.lower() or "2160p" in post.title.lower():
-                                continue
-                            found = True
-                        else:
-                            found = re.search(ss, post.title.lower())
-                        if found:
-                            sss = r"[\.-]+" + self.allInfos[key][1].lower()
-                            found = re.search(sss, post.title.lower())
-
-                            if self.allInfos[key][2]:
-                                found = all([word in post.title.lower()
-                                             for word in self.allInfos[key][2]])
-                            if found:
-                                episode = re.search(
-                                    r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
-                                if episode:
-                                    self.log_debug(
-                                        "%s - Release ignoriert (Serienepisode)" % post.title)
+                        if self.filename == 'MB_Filme':
+                            if ss == "480p":
+                                if "720p" in post.title.lower() or "1080p" in post.title.lower() or "1080i" in post.title.lower() or "2160p" in post.title.lower():
                                     continue
-                                yield (post.title, content, key)
-                    else:
-                        yield (post.title, content, key)
+                                found = True
+                            else:
+                                found = re.search(ss, post.title.lower())
+                            if found:
+                                sss = r"[\.-]+" + self.allInfos[key][1].lower()
+                                found = re.search(sss, post.title.lower())
+                                if self.allInfos[key][2]:
+                                    found = all([word in post.title.lower()
+                                                 for word in self.allInfos[key][2]])
+                                if found:
+                                    episode = re.search(
+                                        r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
+                                    if episode:
+                                        self.log_debug(
+                                            "%s - Release ignoriert (Serienepisode)" % post.title)
+                                        continue
+                                    yield (post.title, content, key)
+                        elif self.filename == 'MB_3D':
+                            if '.3d.' in post.title.lower():
+                                if self.config.get('crawl3d') and (
+                                        "1080p" in post.title.lower() or "1080i" in post.title.lower()):
+                                    if not self.config.get("crawl3dtype"):
+                                        c3d_type = "hsbs"
+                                    else:
+                                        c3d_type = self.config.get("crawl3dtype")
+                                    if c3d_type == "hsbs":
+                                        if re.match(r'.*\.(H-OU|HOU)\..*', post.title):
+                                            self.log_debug(
+                                                "%s - Release ignoriert (Falsches 3D-Format)" % post.title)
+                                            continue
+                                    elif c3d_type == "hou":
+                                        if not re.match(r'.*\.(H-OU|HOU)\..*', post.title):
+                                            self.log_debug(
+                                                "%s - Release ignoriert (Falsches 3D-Format)" % post.title)
+                                            continue
+                                    found = True
+                                else:
+                                    continue
+                            if found:
+                                sss = r"[\.-]+" + self.allInfos[key][1].lower()
+                                found = re.search(sss, post.title.lower())
+                                if self.allInfos[key][2]:
+                                    found = all([word in post.title.lower()
+                                                 for word in self.allInfos[key][2]])
+                                if found:
+                                    episode = re.search(
+                                        r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
+                                    if episode:
+                                        self.log_debug(
+                                            "%s - Release ignoriert (Serienepisode)" % post.title)
+                                        continue
+                                    yield (post.title, content, key)
+
+                        elif self.filename == 'MB_Staffeln':
+                            validsource = re.search(self.config.get(
+                                "seasonssource"), post.title.lower())
+                            if not validsource:
+                                self.log_debug(
+                                    post.title + " - Release hat falsche Quelle")
+                                continue
+                            if not ".complete." in post.title.lower():
+                                self.log_debug(
+                                    post.title + " - Staffel noch nicht komplett")
+                                continue
+                            season = re.search(r"\.s\d", post.title.lower())
+                            if not season:
+                                self.log_debug(
+                                    post.title + " - Release ist keine Staffel")
+                                continue
+                            if not self.config.get("seasonpacks"):
+                                staffelpack = re.search(
+                                    r"s\d.*(-|\.).*s\d", post.title.lower())
+                                if staffelpack:
+                                    self.log_debug(
+                                        "%s - Release ignoriert (Staffelpaket)" % post.title)
+                                    continue
+                            ss = self.allInfos[key][0].lower()
+
+                            if ss == "480p":
+                                if "720p" in post.title.lower() or "1080p" in post.title.lower() or "1080i" in post.title.lower() or "2160p" in post.title.lower():
+                                    continue
+                                found = True
+                            else:
+                                found = re.search(ss, post.title.lower())
+                            if found:
+                                sss = r"[\.-]+" + self.allInfos[key][1].lower()
+                                found = re.search(sss, post.title.lower())
+
+                                if self.allInfos[key][2]:
+                                    found = all([word in post.title.lower()
+                                                 for word in self.allInfos[key][2]])
+                                if found:
+                                    episode = re.search(
+                                        r'([\w\.\s]*s\d{1,2}e\d{1,2})[\w\.\s]*', post.title.lower())
+                                    if episode:
+                                        self.log_debug(
+                                            "%s - Release ignoriert (Serienepisode)" % post.title)
+                                        continue
+                                    yield (post.title, content, key)
+                        else:
+                            yield (post.title, content, key)
 
     def download_dl(self, title):
         search_title = title.replace(".German.720p.", ".German.DL.1080p.").replace(".German.DTS.720p.",
@@ -1473,6 +1475,7 @@ class BL:
                     if not self.download_dl(key):
                         self.log_debug(
                             "%s - Kein zweisprachiges Release gefunden." % key)
+                        self.dl_unsatisfied = True
                 else:
                     if isinstance(imdb_id, list):
                         imdb_id = imdb_id.pop()
@@ -1492,6 +1495,7 @@ class BL:
                         if not self.download_dl(key) and not englisch:
                             self.log_debug(
                                 "%s - Kein zweisprachiges Release gefunden! Breche ab." % key)
+                            self.dl_unsatisfied = True
                             return
             if self.filename == 'MB_Filme':
                 retail = False
@@ -1730,10 +1734,13 @@ class BL:
                         i += 1
 
         if sha_mb and sha_hw:
-            self.cdc.delete("MB-" + self.filename)
-            self.cdc.delete("HW-" + self.filename)
-            self.cdc.store("MB-" + self.filename, sha_mb)
-            self.cdc.store("HW-" + self.filename, sha_hw)
+            if not self.dl_unsatisfied:
+                self.cdc.delete("MB-" + self.filename)
+                self.cdc.delete("HW-" + self.filename)
+                self.cdc.store("MB-" + self.filename, sha_mb)
+                self.cdc.store("HW-" + self.filename, sha_hw)
+            else:
+                self.log_debug("Für ein oder mehrere Release(s) wurde kein zweisprachiges gefunden. Setze kein neues CDC!")
 
 
 if __name__ == "__main__":

--- a/RSScrawler.py
+++ b/RSScrawler.py
@@ -1508,6 +1508,10 @@ class BL:
                         else:
                             if common.cutoff(key, '0'):
                                 retail = True
+                else:
+                    if self.config.get('cutoff') and '.COMPLETE.' not in key.lower():
+                        if common.cutoff(key, '0'):
+                            retail = True
                 common.write_crawljob_file(
                     key,
                     key,
@@ -1535,6 +1539,10 @@ class BL:
                         if self.config.get('enforcedl'):
                             if common.cutoff(key, '2'):
                                 retail = True
+                else:
+                    if self.config.get('cutoff') and '.COMPLETE.' not in key.lower():
+                        if common.cutoff(key, '2'):
+                            retail = True
                 common.write_crawljob_file(
                     key,
                     key,

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@
 # https://github.com/rix1337/RSScrawler/issues/88#issuecomment-251078409
 # https://github.com/rix1337/RSScrawler/issues/7#issuecomment-271187968
 
-VERSION="v.4.2.6"
+VERSION="v.4.2.7"
 echo "┌────────────────────────────────────────────────────────┐"
 echo "  Programminfo:    RSScrawler $VERSION von RiX"
 echo "  Projektseite:    https://github.com/rix1337/RSScrawler"

--- a/version.py
+++ b/version.py
@@ -7,7 +7,7 @@ import urllib2
 
 
 def getVersion():
-    return "v.4.2.6"
+    return "v.4.2.7"
 
 
 def updateCheck():

--- a/web/index.html
+++ b/web/index.html
@@ -316,26 +316,26 @@
                     <h4>JDownloader-Pfad</h4>
                     <input required ng-model="settings.general.pfad" class="form-control docker" data-toggle="tooltip"
                            data-placement="top"
-                           title="Exakt das Verzeichnis des JDownloaders angeben, sonst funktioniert das Script nicht - Die Orderüberwachung muss aktiv sein und auf dessen Unterordner folderwatch verweisen"></input>
+                           title="Exakt das Verzeichnis des JDownloaders angeben, sonst funktioniert das Script nicht - Die Orderüberwachung muss aktiv sein und auf dessen Unterordner folderwatch verweisen"/>
                     </p>
                     <p>
                     <h4>Port</h4>
                     <input required type="number" min="1" max="65535" ng-model="settings.general.port"
                            class="form-control docker" data-toggle="tooltip"
-                           data-placement="top" title="Hier den Port des Webservers wählen"></input>
+                           data-placement="top" title="Hier den Port des Webservers wählen"/>
                     </p>
                     <p>
                     <h4>Prefix</h4>
                     <input ng-model="settings.general.prefix" class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Hier den Prefix des Webservers wählen (nützlich für Reverse-Proxies)"></input>
+                           title="Hier den Prefix des Webservers wählen (nützlich für Reverse-Proxies)"/>
                     </p>
                     <p>
                     <h4>Suchintervall</h4>
                     <input required type="number" min="5" max="1440" ng-model="settings.general.interval"
                            class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Das Suchintervall in Minuten sollte nicht zu niedrig angesetzt werden, um keinen Ban zu riskieren - Minimum sind 5 Minuten"></input>
+                           title="Das Suchintervall in Minuten sollte nicht zu niedrig angesetzt werden, um keinen Ban zu riskieren - Minimum sind 5 Minuten"/>
                     </p>
                     <p>
                     <h4>Englische Releases hinzufügen</h4>
@@ -355,7 +355,7 @@
                     <h4>Proxy</h4>
                     <input ng-model="settings.general.proxy" class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Hier die URL eines offenen (lokalen) Proxies eingeben; bspw. http://192.168.0.1:8080"></input>
+                           title="Hier die URL eines offenen (lokalen) Proxies eingeben; bspw. http://192.168.0.1:8080"/>
                     </p>
                     <p>
                     <h4>Proxy-Fallback</h4>
@@ -382,19 +382,19 @@
                     <h4>Pushbullet</h4>
                     <input ng-model="settings.alerts.pushbullet" class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Access-Token auf Pushbullet.com anlegen und hier angeben"></input>
+                           title="Access-Token auf Pushbullet.com anlegen und hier angeben"/>
                     </p>
                     <p>
                     <h4>Pushover</h4>
                     <input ng-model="settings.alerts.pushover" class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Hier durch ein Komma getrennt (Keine Leerzeichen!) den User-Key und danach einen API-Token eingeben - Für letzteren zunächst eine App auf Pushover.net anlegen"></input>
+                           title="Hier durch ein Komma getrennt (Keine Leerzeichen!) den User-Key und danach einen API-Token eingeben - Für letzteren zunächst eine App auf Pushover.net anlegen"/>
                     </p>
                     <p>
                     <h4>Home Assistant</h4>
                     <input ng-model="settings.alerts.homeassistant" class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Hier durch ein Komma getrennt (Keine Leerzeichen!) die URL zur API und danach das Passwort angeben"></input>
+                           title="Hier durch ein Komma getrennt (Keine Leerzeichen!) die URL zur API und danach das Passwort angeben"/>
                     </p>
                 </div>
             </div>
@@ -461,7 +461,7 @@
                     <p>
                     <h4>Filterliste</h4>
                     <input ng-model="settings.mb.ignore" class="form-control" data-toggle="tooltip" data-placement="top"
-                           title="Releases mit diesen Begriffen werden nicht hinzugefügt (durch Kommata getrennt)"></input>
+                           title="Releases mit diesen Begriffen werden nicht hinzugefügt (durch Kommata getrennt)"/>
                     </p>
                     <p>
                     <h4>Auch per RegEx suchen</h4>
@@ -475,14 +475,14 @@
                     <input required type="number" step="0.1" ng-model="settings.mb.imdb_score" min="0.0" max="10.0"
                            class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Alle Filme die im Feed über der genannten Wertung auftauchen, werden hinzugefügt - Wert unter 6.5 nicht empfehlenswert, 0.0 zum Deaktivieren"></input>
+                           title="Alle Filme die im Feed über der genannten Wertung auftauchen, werden hinzugefügt - Wert unter 6.5 nicht empfehlenswert, 0.0 zum Deaktivieren"/>
                     </p>
                     <p>
                     <h4>IMDB hinzufügen ab Erscheinungsjahr</h4>
                     <input id="year" type="number" min="1900" max="2100" ng-model="settings.mb.imdb_year"
                            class="form-control" data-toggle="tooltip"
                            data-placement="top"
-                           title="Berücksichtige Filme bei IMDB-Suche erst ab diesem Erscheinungsjahr"></input>
+                           title="Berücksichtige Filme bei IMDB-Suche erst ab diesem Erscheinungsjahr"/>
                     </p>
                     <p>
                     <h4>Zweisprachige Releases erzwingen</h4>
@@ -541,7 +541,7 @@
                     <p>
                     <h4>Filterliste</h4>
                     <input ng-model="settings.sj.ignore" class="form-control" data-toggle="tooltip" data-placement="top"
-                           title="Releases mit diesen Begriffen werden nicht hinzugefügt (durch Kommata getrennt)"></input>
+                           title="Releases mit diesen Begriffen werden nicht hinzugefügt (durch Kommata getrennt)"/>
                     </p>
                     <p>
                     <h4>Auch per RegEx suchen</h4>
@@ -614,7 +614,7 @@
                     <p>
                     <h4>Feeds</h4>
                     <input ng-model="settings.dd.feeds" class="form-control" data-toggle="tooltip" data-placement="top"
-                           title="Hier Feeds von DD eintragen (durch Kommata getrennt)"></input>
+                           title="Hier Feeds von DD eintragen (durch Kommata getrennt)"/>
                     </p>
                 </div>
             </div>
@@ -640,12 +640,12 @@
                     <h4>Maximale Videoanzahl</h4>
                     <input required type="number" min="1" max="50" ng-model="settings.yt.max" class="form-control"
                            data-toggle="tooltip" data-placement="top"
-                           title="Die Maximale Anzahl hinzuzufügender Videos (1-50)"></input>
+                           title="Die Maximale Anzahl hinzuzufügender Videos (1-50)"/>
                     </p>
                     <p>
                     <h4>Filterliste</h4>
                     <input ng-model="settings.yt.ignore" class="form-control" data-toggle="tooltip" data-placement="top"
-                           title="Videos mit diesen Begriffen im Titel werden nicht hinzugefügt (durch Kommata getrennt)"></input>
+                           title="Videos mit diesen Begriffen im Titel werden nicht hinzugefügt (durch Kommata getrennt)"/>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
* Prüfe, ob Release-Beschreibung bei Blogs "MKV" enthält um ISO, EXE, etc. zu ignorieren
* Wenn DL-Suche erzwungen wird, und kein passendes Release gezwungen wird, ist die CDC-Funktion zu deaktivieren, um das nicht-DL Release im nächsten Lauf erneut zu berücksichtigen
* Erkenne Retails, auch ohne DL-Tag im Titel