### PR TITLE
v.5.4.0 - Nutze pycryptodomex statt pycryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask
 fuzzywuzzy
 gevent
 lxml
-pycryptodome
+pycryptodomex
 python-dateutil
 requests[socks]
 six

--- a/rsscrawler/myjdapi.py
+++ b/rsscrawler/myjdapi.py
@@ -39,7 +39,7 @@ except:  # For Python 2
     # from urllib import urlopen
 import base64
 import requests
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 BS = 16
 

--- a/rsscrawler/version.py
+++ b/rsscrawler/version.py
@@ -10,7 +10,7 @@ from six.moves.urllib.request import urlopen
 
 
 def get_version():
-    return "v.5.3.7"
+    return "v.5.4.0"
 
 
 def update_check():


### PR DESCRIPTION
* Verhindert Probleme, wenn altes Pycrypto noch installiert ist
* Codeseitig sind beide Bibliotheken identisch