### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Hinweise zur manuellen Installation und Einrichtung finden sich im [Wiki](https:
 
 Die folgenden Fehler lassen sich nicht im Code von RSScrawler beheben, sondern nur auf Systemseite:
 
-* Python _Levenshtein_ wird ausschließlich in der Suche per Webinterface/API von der _fuzzywuzzy_ Bibliothek verwendet, die notfalls auf eine langsamere Alternative ausweicht. Die Warnung beim Start, dass das Modul fehlt, lässt sich optional per `pip install python-Levenshtein` vermeiden.
 * Fehler im Installationsprozess per _pip_ deuten auf fehlende Compiler im System hin. Meist muss ein Zusatzpaket nachinstalliert werden (Beispielsweise die [VS C++ Build Tools](https://aka.ms/vs/16/release/vs_buildtools.exe) für Windows oder libffi per `apt-get install libffi-dev` für den Raspberry Pi).
 
 #### Update

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cloudscraper
 docopt
 feedparser
 flask
-fuzzywuzzy
+rapidfuzz
 gevent
 lxml
 passlib

--- a/rsscrawler/myjd.py
+++ b/rsscrawler/myjd.py
@@ -5,7 +5,7 @@
 import re
 import time
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 import rsscrawler.myjdapi
 from rsscrawler.rsscommon import check_hoster

--- a/rsscrawler/search.py
+++ b/rsscrawler/search.py
@@ -9,7 +9,7 @@ import re
 
 import cloudscraper
 from bs4 import BeautifulSoup
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from rsscrawler.fakefeed import fx_content_to_soup
 from rsscrawler.fakefeed import fx_download_links


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. (since apparently here python-Levenshtein is not always used even faster)